### PR TITLE
index.html: use channel name in web.libera.chat link

### DIFF
--- a/tnnt/templates/index.html
+++ b/tnnt/templates/index.html
@@ -93,8 +93,7 @@
     on #nethack-tnnt (IRC to Discord bridge is active). All TNNT discussion is
     on-topic in these channels, and this is the best way to reach the admins if
     you have any issues.
-    <a href="https://web.libera.chat" target="_blank">Click here to open IRC chat.</a> Enter
-    "#tnnt" for the channel.
+    <a href="https://web.libera.chat/#tnnt" target="_blank">Click here to open IRC chat.</a>
   </p>
 </article>
 


### PR DESCRIPTION
This autofills the channel field, so the user no longer has to manually fill it in.